### PR TITLE
Getting Started Installation section

### DIFF
--- a/input/docs/getting-started/installation/avalonia.md
+++ b/input/docs/getting-started/installation/avalonia.md
@@ -1,5 +1,5 @@
 Title: Avalonia
-Order: 90
+Order: 100
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/q6uWPtKw3UQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/input/docs/getting-started/installation/blazor.md
+++ b/input/docs/getting-started/installation/blazor.md
@@ -1,0 +1,17 @@
+Title: Blazor
+Order: 90
+---
+
+# Package Installation
+
+Assuming the following project structure:
+
+```
+- MyCoolApp (netstandard library)
+- MyCoolApp.Blazor (application)
+- MyCoolApp.UnitTests (tests)
+```
+
+* Install `ReactiveUI` into your netstandard libraries, application and tests.
+* Install `ReactiveUI.Blazor` into your application.
+* Install `ReactiveUI.Testing` into your tests.

--- a/input/docs/getting-started/installation/index.md
+++ b/input/docs/getting-started/installation/index.md
@@ -86,7 +86,7 @@ ReactiveUI packages are now signed by the dotnet foundation. Only builds from th
 
 [Blaz]: https://www.nuget.org/packages/ReactiveUI.Blazor/
 [BlazBadge]: https://img.shields.io/nuget/v/ReactiveUI.Blazor.svg
-[BlazDoc]: https://www.reactiveui.net/blog/2020/07/article-blazor-compelling-example
+[BlazDoc]: https://reactiveui.net/docs/getting-started/installation/blazor
 
 [Ava]: https://www.nuget.org/packages/Avalonia.ReactiveUI/
 [AvaBadge]: https://img.shields.io/nuget/v/Avalonia.ReactiveUI.svg
@@ -140,6 +140,8 @@ ReactiveUI is published to [NuGet.org](https://www.nuget.org/packages?q=Reactive
 
 - ReactiveUI
     - [ReactiveUI](https://www.nuget.org/packages/ReactiveUI/) is the base package that has the base platform implementations.
+ ReactiveUI.Blazor
+    - [ReactiveUI.Blazor](https://www.nuget.org/packages/ReactiveUI.Blazor/) this package has ReactiveUI platform specific extensions for Blazor
 - ReactiveUI.Events
     - [ReactiveUI.Events](https://www.nuget.org/packages/ReactiveUI.Events/) is the base package for ReactiveUI Events as Observables API.
 - ReactiveUI.WinForms

--- a/input/docs/getting-started/installation/index.md
+++ b/input/docs/getting-started/installation/index.md
@@ -140,7 +140,7 @@ ReactiveUI is published to [NuGet.org](https://www.nuget.org/packages?q=Reactive
 
 - ReactiveUI
     - [ReactiveUI](https://www.nuget.org/packages/ReactiveUI/) is the base package that has the base platform implementations.
- ReactiveUI.Blazor
+ - ReactiveUI.Blazor
     - [ReactiveUI.Blazor](https://www.nuget.org/packages/ReactiveUI.Blazor/) this package has ReactiveUI platform specific extensions for Blazor
 - ReactiveUI.Events
     - [ReactiveUI.Events](https://www.nuget.org/packages/ReactiveUI.Events/) is the base package for ReactiveUI Events as Observables API.

--- a/input/docs/guidelines/platform/blazor.md
+++ b/input/docs/guidelines/platform/blazor.md
@@ -28,9 +28,12 @@ Use disposables to manage lifetime, scope and resources:
 
 Your Page (View) should inherit from
 
-- `[ReactiveComponentBase<T>](https://www.reactiveui.net/api/reactiveui.blazor/reactivecomponentbase_1/)`: If you want to instantiate your ViewModel corresponding to the View, then set the ViewModel property in the Page's code behind.  
-- `[ReactiveInjectableComponentBase<T>](https://www.reactiveui.net/api/reactiveui.blazor/reactiveinjectablecomponentbase_1/)`: If you want that your corresponding ViewModel should be injected by the dependency injection container.
-- `[ReactiveLayoutComponentBase](https://www.reactiveui.net/api/reactiveui.blazor/reactivelayoutcomponentbase_1/)`:
+- [ReactiveComponentBase<T>](https://www.reactiveui.net/api/reactiveui.blazor/reactivecomponentbase_1/): If you want to instantiate your ViewModel corresponding to the View, then set the ViewModel property in the Page's code behind.  
+- [ReactiveInjectableComponentBase<T>](https://www.reactiveui.net/api/reactiveui.blazor/reactiveinjectablecomponentbase_1/): If you want that your corresponding ViewModel should be injected by the dependency injection container.
+- [ReactiveLayoutComponentBase](https://www.reactiveui.net/api/reactiveui.blazor/reactivelayoutcomponentbase_1/):
 
 
 Use your normal Blazor concepts that you would usually use in Blazor development. There's also some extension methods which will make your life easier
+
+Useful links
+- [ReactiveUI On The Web with Blazor](https://www.reactiveui.net/blog/2020/07/article-blazor-compelling-example)


### PR DESCRIPTION
- Added Getting Started Installation section
- Changed the BlazDoc link to install section and put the old blog link to the platform specific page
- Fixed markup in input/docs/guidelines/platform/blazor.md